### PR TITLE
Reference to array in swagger file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>blog.svenbayer</groupId>
     <artifactId>spring-cloud-contract-swagger</artifactId>
-    <version>1.2.1.BUILD-SNAPSHOT</version>
+    <version>1.2.2.BUILD-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>blog.svenbayer:spring-cloud-contract-swagger</name>
@@ -116,6 +116,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.0.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/reference/SwaggerDefinitionsRefResolverSwagger.java
+++ b/src/main/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/reference/SwaggerDefinitionsRefResolverSwagger.java
@@ -4,10 +4,15 @@ import blog.svenbayer.springframework.cloud.contract.verifier.spec.swagger.build
 import blog.svenbayer.springframework.cloud.contract.verifier.spec.swagger.exception.SwaggerContractConverterException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -36,17 +41,17 @@ public class SwaggerDefinitionsRefResolverSwagger implements SwaggerReferenceRes
 	}
 
 	/**
-	 * Creats a key-value representation for the given reference and Swagger model definitions.
+	 * Creates a key-value representation for the given reference and Swagger model definitions.
 	 *
 	 * @param definitions the Swagger model definitions
 	 * @return a json representation of the Swagger model definition
 	 */
 	@Override
 	public String resolveReference(Map<String, Model> definitions) {
-		Map<String, Object> jsonMap = resolveDefinitionsRef(this.reference, definitions);
+		Object definition = resolveDefinitionsRef(this.reference, definitions);
 		try {
 			ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
-			String jsonString = mapper.writeValueAsString(jsonMap);
+			String jsonString = mapper.writeValueAsString(definition);
 			String cleanJson = cleanupJson(jsonString);
 			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mapper.readTree(cleanJson));
 		} catch (IOException e) {
@@ -55,7 +60,7 @@ public class SwaggerDefinitionsRefResolverSwagger implements SwaggerReferenceRes
 	}
 
 	/**
-	 * Cleans up a json-fied Json string.
+	 * Cleans up a json-field Json string.
 	 *
 	 * @param jsonString the Json string that got mapped to often by ObjectMapper
 	 * @return the cleaned-up Json string
@@ -68,18 +73,62 @@ public class SwaggerDefinitionsRefResolverSwagger implements SwaggerReferenceRes
 	}
 
 	/**
-	 * Resolves a Swagger reference with the given Swagger definitions.
+	 * Resolves a Swagger reference with a given Swagger definitions.
+	 * Resolves only object and array references.
+	 * @param reference   the swagger object/array reference
+	 * @param definitions the Swagger definitions
+	 * @return the representation of the Swagger reference
+	 */
+	private  Object resolveDefinitionsRef(String reference, Map<String, Model> definitions)
+	{
+		String referenceName = reference.substring(reference.lastIndexOf('/') + 1);
+		if (definitions == null || definitions.get(referenceName) == null) {
+			throw new SwaggerContractConverterException("Reference '" + reference + "' does not exist in definitions");
+		}
+
+		if (definitions.get(referenceName) instanceof ArrayModel)
+		{
+			return resolveArrayDefinitionsRef(reference, definitions);
+		}
+		else
+		{
+			return resolveObjectDefinitionsRef(reference, definitions);
+		}
+	}
+
+	/**
+	 * Resolves a Swagger object reference with the given Swagger definitions.
 	 *
-	 * @param reference   the Swagger reference
+	 * @param reference   the Swagger object reference
 	 * @param definitions the Swagger definitions
 	 * @return the key-value representation of the Swagger reference
 	 */
-	private Map<String, Object> resolveDefinitionsRef(String reference, Map<String, Model> definitions) {
+	private Map<String, Object> resolveObjectDefinitionsRef(String reference, Map<String, Model> definitions) {
 		String referenceName = reference.substring(reference.lastIndexOf('/') + 1);
-		if (definitions == null || definitions.get(referenceName) == null || definitions.get(referenceName).getProperties() == null) {
-			throw new SwaggerContractConverterException("Could not resolve reference '" + reference + "'");
+		if (definitions.get(referenceName).getProperties() == null) {
+			throw new SwaggerContractConverterException("The object '" + reference + "' does not have properties");
 		}
 		return definitions.get(referenceName).getProperties().entrySet().stream()
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> this.responseHeaderValueBuilder.createResponseHeaderValue(entry.getKey(), entry.getValue(), definitions)));
+	}
+
+	/**
+	 * Resolves a Swagger array reference with the given Swagger definitions.
+	 * @param reference   the Swagger array reference
+	 * @param definitions the Swagger definitions
+	 * @return the list representation of the Swagger reference
+	 */
+	private List<Object> resolveArrayDefinitionsRef(String reference, Map<String, Model> definitions)
+	{
+		String referenceName = reference.substring(reference.lastIndexOf('/') + 1);
+		Property items = ((ArrayModel)definitions.get(referenceName)).getItems();
+
+		if (items == null) {
+			throw new SwaggerContractConverterException("The array '" + reference + "' does not have items");
+		}
+
+		Object responseHeaderValue = this.responseHeaderValueBuilder
+				.createResponseHeaderValue(definitions.get(referenceName).getTitle(), items, definitions);
+		return Collections.singletonList(responseHeaderValue);
 	}
 }

--- a/src/test/groovy/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/ComplexSwaggerContractSpec.groovy
+++ b/src/test/groovy/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/ComplexSwaggerContractSpec.groovy
@@ -20,7 +20,37 @@ class ComplexSwaggerContractSpec extends Specification {
     def "should convert from single parametrized swagger to contract"() {
         given:
         File singleSwaggerYaml = new File(SwaggerContractConverterSpec.getResource("/swagger/complex_definitions/param_swagger.yml").toURI())
-        Contract expectedContract = Contract.make {
+        Contract expectedContractGet = Contract.make {
+            label("coffee_bean")
+            name("2_beans_GET")
+            description("API endpoint to get all coffee beans")
+            priority(2)
+            request {
+                method(GET())
+                urlPath("/coffee-rocket-service/v1.0/beans") {
+                    queryParameters {
+                        parameters []
+                    }
+                }
+                headers {}
+            }
+            response {
+                status(200)
+                headers {}
+                body(
+                        """[{
+  "asteroids" : [ {
+    "shape" : "BEAN",
+    "name" : "Phobos",
+    "speed" : 23
+  } ],
+  "size" : 6779,
+  "name" : "Mars"
+}]""")
+            }
+
+        }
+        Contract expectedContractPost = Contract.make {
             label("takeoff_coffee_bean_rocket")
             name("1_takeoff_POST")
             description("API endpoint to send a coffee rocket to a bean planet and returns the bean planet.")
@@ -73,6 +103,6 @@ class ComplexSwaggerContractSpec extends Specification {
         when:
         Collection<Contract> contracts = converter.convertFrom(singleSwaggerYaml)
         then:
-        testContractEquals.assertContractEquals(Collections.singleton(expectedContract), contracts)
+        testContractEquals.assertContractEquals(Arrays.asList(expectedContractPost, expectedContractGet), contracts)
     }
 }

--- a/src/test/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/TestContractEquals.java
+++ b/src/test/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/TestContractEquals.java
@@ -1,6 +1,8 @@
 package blog.svenbayer.springframework.cloud.contract.verifier.spec.swagger.builder;
 
+import org.json.JSONException;
 import org.junit.jupiter.api.function.Executable;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.cloud.contract.spec.Contract;
 import org.springframework.cloud.contract.spec.internal.*;
 
@@ -189,7 +191,8 @@ public class TestContractEquals {
 		assertAll("header", headerExecutables.stream());
 	}
 
-	private static void assertPossiblePatternEquals(Object expected, Object actual, String msg) {
+	private static void assertPossiblePatternEquals(Object expected, Object actual, String msg)
+	{
 		if (expected instanceof Pattern) {
 			msg = msg + "Pattern:\n";
 			assertEquals(Pattern.class, actual.getClass(), msg);
@@ -216,14 +219,22 @@ public class TestContractEquals {
 		}
 	}
 
-	private static void assertEqualsNoLineSeparator(Object expected, Object actual, String msg) {
+	private static void assertEqualsNoLineSeparator(Object expected, Object actual, String msg)
+	{
 		if (expected == null) {
 			assertNull(actual, msg);
 		} else {
 			assertNotNull(actual, msg);
 			String cleanedUpExpected = expected.toString().replaceAll(LINE_SEPS, System.lineSeparator());
 			String cleanedUpActual = actual.toString().replaceAll(LINE_SEPS, System.lineSeparator());
-			assertEquals(cleanedUpExpected, cleanedUpActual, msg);
+			try
+			{
+				JSONAssert.assertEquals(cleanedUpExpected, cleanedUpActual, false);
+			}
+			catch (JSONException ex)
+			{
+				assertEquals(cleanedUpExpected, cleanedUpActual, msg);
+			}
 		}
 	}
 }

--- a/src/test/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/reference/SwaggerDefinitionsRefResolverSwaggerTest.java
+++ b/src/test/java/blog/svenbayer/springframework/cloud/contract/verifier/spec/swagger/builder/reference/SwaggerDefinitionsRefResolverSwaggerTest.java
@@ -16,7 +16,7 @@ public class SwaggerDefinitionsRefResolverSwaggerTest {
 		SwaggerContractConverterException exception = assertThrows(SwaggerContractConverterException.class, () -> {
 			resolver.resolveReference(null);
 		});
-		assertEquals("Could not resolve reference '#invalid'", exception.getMessage());
+		assertEquals("Reference '#invalid' does not exist in definitions", exception.getMessage());
 
 	}
 }

--- a/src/test/resources/swagger/complex_definitions/param_swagger.yml
+++ b/src/test/resources/swagger/complex_definitions/param_swagger.yml
@@ -68,6 +68,20 @@ paths:
           description: Forbidden
         '404':
           description: Not Found
+  /beans:
+    get:
+      summary: Gets coffee beans
+      tags:
+        - coffee
+        - bean
+      description: API endpoint to get all coffee beans
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The list of coffee beans
+          schema:
+            $ref: '#/definitions/BeanPlanetList'
 definitions:
   Beanonaut:
     type: object
@@ -143,3 +157,7 @@ definitions:
           - 'BEAN'
         default: 'BEAN'
     title: BeanAsteroids
+  BeanPlanetList:
+    type: array
+    items:
+      $ref: '#/definitions/BeanPlanet'


### PR DESCRIPTION
Swagger allows creating references of type array:

definitions:
  BeanPlanet:
     type: object
     ...
  BeanPlanetList:
    type: array
    items:
      $ref: '#/definitions/BeanPlanet'

So added this functionality to the plugin. Please let me know if there is any issue in the PR. 
Thanks.